### PR TITLE
Fix building on MinGW

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
+import shutil
 
 
 class PhysfsConan(ConanFile):
@@ -48,7 +49,7 @@ class PhysfsConan(ConanFile):
             self.copy("*.dylib", dst="lib", keep_path=False, symlinks=True)
         else:
             self.copy("*-static.lib", dst="lib", keep_path=False)
-            self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
         self.copy("*.pdb", dst="lib", keep_path=False)
 
     def package_info(self):
@@ -57,3 +58,5 @@ class PhysfsConan(ConanFile):
             self.cpp_info.exelinkflags.extend(["-framework IOKit",
                                                "-framework Foundation"])
             self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+            shutil.move(os.path.join(self.package_folder, "lib", "objects.a"), os.path.join(self.package_folder, "lib", "libobjects.a"))

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,7 +49,7 @@ class PhysfsConan(ConanFile):
             self.copy("*.dylib", dst="lib", keep_path=False, symlinks=True)
         else:
             self.copy("*-static.lib", dst="lib", keep_path=False)
-        self.copy("*.a", dst="lib", keep_path=False)
+            self.copy("*.a", dst="lib", keep_path=False)
         self.copy("*.pdb", dst="lib", keep_path=False)
 
     def package_info(self):


### PR DESCRIPTION
This fix addresses ld's inability to find 'objects.a' during the linking stage when building with shared=False, by renaming it to a filename beginning with 'lib'.