### PR TITLE
fixed dll linking occurring in static build on windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,7 +49,7 @@ class PhysfsConan(ConanFile):
             self.copy("*.dylib", dst="lib", keep_path=False, symlinks=True)
         else:
             self.copy("*-static.lib", dst="lib", keep_path=False)
-            self.copy("*.a", dst="lib", keep_path=False)
+            self.copy("*.a", dst="lib", keep_path=False, excludes="*.dll.a")
         self.copy("*.pdb", dst="lib", keep_path=False)
 
     def package_info(self):


### PR DESCRIPTION
By ignoring the dll.a file, the linking that breaks can be avoided.